### PR TITLE
Ignore validation errors via metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,14 @@ match any value at that point in the path. For example, `Resources.MyBucket.*`
 would match all errors related to the `MyBucket` resource, and `*.BucketName`
 would ignore all errors related to properties called `BucketName`.
 
-All LaundryIgnore properties in this example have the same effect.
+All `LaundryIgnore` properties in this example have the same effect:
 
 ```
 Metadata:
   LaundryIgnore:
+    # Match ResourcePropertyValidator errors for a specific property
+    'Resources.A.Properties.Foo':
+      - ResourcePropertyValidator
     # Match any ResourcePropertyValidator errors under "Resources.A"
     'Resources.A.*':
       - ResourcePropertyValidator

--- a/README.md
+++ b/README.md
@@ -44,6 +44,40 @@ Better validation can be done if parameter values are provided:
 lint('...', { ParamA: 1, ParamB: 'two'});
 ```
 
+## Ignoring Errors
+
+Errors can be ignored via the `LaundryIgnore` `Metadata` property. The top-level
+`Metadata` property is specified as a map of paths within the CloudFormation
+template, written in dot notation. The `*` character can be used as a glob to
+match any value at that point in the path. For example, `Resources.MyBucket.*`
+would match all errors related to the `MyBucket` resource, and `*.BucketName`
+would ignore all errors related to properties called `BucketName`.
+
+All LaundryIgnore properties in this example have the same effect.
+
+```
+Metadata:
+  LaundryIgnore:
+    # Match any ResourcePropertyValidator errors under "Resources.A"
+    'Resources.A.*':
+      - ResourcePropertyValidator
+    # Match any ResourcePropertyValidator errors for properties named "Foo"
+    '*.Foo':
+      - ResourcePropertyValidator
+    # Ignore all ResourcePropertyValidator errors
+    '*':
+      - ResourcePropertyValidator
+Resources:
+  A:
+    Metadata:
+      # Ignore ResourcePropertyValidator errors for this resource
+      LaundryIgnore:
+        - ResourcePropertyValidator
+    Type: AWS::S3::Bucket
+    Properties:
+      Foo: bar
+```
+
 ## Development
 
 Run tests using `npm test` or to do so in "watch" mode, use `npm start`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Options:
   --help     Show help                                                 [boolean]
 ```
 
+```
+$ cat test.yaml
+Resources: ''
+$ laundry lint test.yaml
+Root.Resources: must be an Object, got "" [RootValidator]
+```
+
 ## Library
 
 ```javascript

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ export function main() {
           template = fs.readFileSync(argv.template).toString();
           const errors = lint(template);
           for (const error of errors) {
-            console.log(`${error.path.join('.')}: ${error.message}`);
+            console.log(`${error.path.join('.')}: ${error.message} [${error.source}]`);
           }
           if (errors.length > 0) {
             process.exit(1);

--- a/src/validators/LaundryIgnore.ts
+++ b/src/validators/LaundryIgnore.ts
@@ -1,0 +1,48 @@
+import * as _ from 'lodash';
+import { Path, Error } from '../types';
+import { Validator } from '../validate';
+import * as validate from '../validate';
+
+export type IgnoredValidator = {
+  path: Path,
+  source: string
+}
+
+export default class LaundryIgnore extends Validator {
+  constructor(public ignoredValidators: IgnoredValidator[], errors: Error[]) {
+    super(errors);
+  }
+
+  Metadata(path: Path, metadata: any): void {
+    if(_.isObject(metadata) && 'LaundryIgnore' in metadata) {
+      const laundryIgnore = metadata['LaundryIgnore'];
+      for (const key in laundryIgnore) {
+        const validators = laundryIgnore[key];
+        if (validate.list(path.concat(key), validators, this.addError, validate.string)) {
+          for (const rule of validators) {
+            this.ignoredValidators.push({
+              path: `Root.${key}`.split('.'),
+              source: rule
+            });
+          }
+        }
+      }
+    }
+  }
+
+  Resource(path: Path, resource: any): void {
+    if(_.isObject(resource) && 'Metadata' in resource) {
+      if(_.isObject(resource.Metadata) && 'LaundryIgnore' in resource.Metadata) {
+        const validators = resource.Metadata.LaundryIgnore;
+        if (validate.list(path.concat(['Metadata', 'LaundryIgnore']), validators, this.addError, validate.string)) {
+          for (const source of validators) {
+            this.ignoredValidators.push({
+              path: path.concat('*'),
+              source
+            });
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Errors can be ignored via the `LaundryIgnore` `Metadata` property. The top-level `Metadata` property is specified as a map of paths within the CloudFormation template, written in dot notation. The `*` character can be used as a glob to match any value at that point in the path. For example, `Resources.MyBucket.*` would match all errors related to the `MyBucket` resource, and `*.BucketName` would ignore all errors related to properties called `BucketName`.

All LaundryIgnore properties in this example have the same effect:

```
Metadata:
  LaundryIgnore:
    # Match ResourcePropertyValidator errors for a specific property
    'Resources.A.Properties.Foo':
      - ResourcePropertyValidator
    # Match any ResourcePropertyValidator errors under "Resources.A"
    'Resources.A.*':
      - ResourcePropertyValidator
    # Match any ResourcePropertyValidator errors for properties named "Foo"
    '*.Foo':
      - ResourcePropertyValidator
    # Ignore all ResourcePropertyValidator errors
    '*':
      - ResourcePropertyValidator
Resources:
  A:
    Metadata:
      # Ignore ResourcePropertyValidator errors for this resource
      LaundryIgnore:
        - ResourcePropertyValidator
    Type: AWS::S3::Bucket
    Properties:
      Foo: bar
```

Fixes #4